### PR TITLE
Поддержка UTF-8 в QR коде

### DIFF
--- a/RdlCri/QrCode.cs
+++ b/RdlCri/QrCode.cs
@@ -5,6 +5,7 @@ using fyiReporting.RDL;
 using System.Drawing;
 using System.ComponentModel;
 using System.Xml;
+using ZXing;
 
 namespace fyiReporting.CRI
 {
@@ -39,6 +40,8 @@ namespace fyiReporting.CRI
 			var writer = new ZXing.BarcodeWriter();
 #endif
 			writer.Format = ZXing.BarcodeFormat.QR_CODE;
+
+			writer.Options.Hints.Add(new KeyValuePair<EncodeHintType, object>(EncodeHintType.CHARACTER_SET, "UTF-8"));
 
             Graphics g = null;
             g = Graphics.FromImage(bm);


### PR DESCRIPTION
Сейчас если в qr код зашифровать кириллические символы, то при сканировании QR получаем вместо кириллических символов кракозябры. Добавление этой опции включает поддержку utf-8 и кириллица нормально кодируется.